### PR TITLE
Re-add Task overloads as extension members

### DIFF
--- a/TaskBuilder.fs
+++ b/TaskBuilder.fs
@@ -300,3 +300,14 @@ module ContextInsensitive =
     let task = TaskBuilder.ContextInsensitiveTaskBuilder()
     let inline unitTask (t : Task) = t.ConfigureAwait(false)
 
+
+[<AutoOpen>]
+/// Extension methods have a lower priority than actual members,
+/// so this way type inference will prefer the Task<'T> overload over the non-generic Task overload defined here.
+module LowPriorityExtensions =
+    open TaskBuilder
+    type TaskBuilder with
+        member inline self.Bind(t:Task, continuation) = self.Bind (UnitTask t, continuation)
+        member inline self.ReturnFrom(t : Task) = self.ReturnFrom(UnitTask t)
+    type ContextInsensitiveTaskBuilder with
+        member inline self.Bind(t:Task, continuation) = self.Bind (t.ConfigureAwait(false), continuation)


### PR DESCRIPTION
fixes https://github.com/rspeele/TaskBuilder.fs/issues/2
see https://github.com/Microsoft/visualfsharp/issues/3281#issuecomment-312002714

In a quick test this didn't seem to have any adverse effects, I will test it in my other projects as well.

----------

Edit: seems I was too optimistic, CI didn't like it. :\