### PR TITLE
Publish to NuGet

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/rspeele/TaskBuilder.fs.svg?branch=master)](https://travis-ci.org/rspeele/TaskBuilder.fs)
+[![Build Status](https://travis-ci.org/rspeele/TaskBuilder.fs.svg?branch=master)](https://travis-ci.org/rspeele/TaskBuilder.fs) [![NuGet](https://img.shields.io/nuget/v/TaskBuilder.fs.svg)](https://www.nuget.org/packages/TaskBuilder.fs/)
 
 ## About
 

--- a/TaskBuilder.fs.fsproj
+++ b/TaskBuilder.fs.fsproj
@@ -4,7 +4,7 @@
     <PackageVersion>1.0.0</PackageVersion>
     <PackageId>TaskBuilder.fs</PackageId>
     <Title>TaskBuilder.fs</Title>
-    <Authors>ForNeVeR</Authors>
+    <Authors>humbobst;ForNeVeR</Authors>
     <Description>F# computation expression builder for System.Threading.Tasks</Description>
     <PackageLicenseUrl>https://github.com/rspeele/TaskBuilder.fs/blob/7e11e86a05ce2c10d37ce25f23b06c3fdceae8e5/COPYING</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/rspeele/TaskBuilder.fs</PackageProjectUrl>

--- a/TaskBuilder.fs.fsproj
+++ b/TaskBuilder.fs.fsproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard1.6</TargetFramework>
-    <PackageVersion>1.0.0-pre1</PackageVersion>
-    <PackageId>fornever.TaskBuilder.fs</PackageId>
+    <PackageVersion>1.0.0</PackageVersion>
+    <PackageId>TaskBuilder.fs</PackageId>
     <Title>TaskBuilder.fs</Title>
     <Authors>ForNeVeR</Authors>
     <Description>F# computation expression builder for System.Threading.Tasks</Description>

--- a/TaskBuilder.fs.fsproj
+++ b/TaskBuilder.fs.fsproj
@@ -1,0 +1,19 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netstandard1.6</TargetFramework>
+    <PackageVersion>1.0.0-pre1</PackageVersion>
+    <PackageId>fornever.TaskBuilder.fs</PackageId>
+    <Title>TaskBuilder.fs</Title>
+    <Authors>ForNeVeR</Authors>
+    <Description>F# computation expression builder for System.Threading.Tasks</Description>
+    <PackageLicenseUrl>https://github.com/rspeele/TaskBuilder.fs/blob/7e11e86a05ce2c10d37ce25f23b06c3fdceae8e5/COPYING</PackageLicenseUrl>
+    <PackageProjectUrl>https://github.com/rspeele/TaskBuilder.fs</PackageProjectUrl>
+    <PackageTags>FSharp; Task</PackageTags>
+    <IncludeSymbols>true</IncludeSymbols>
+    <IncludeSource>true</IncludeSource>
+    <RepositoryUrl>https://github.com/rspeele/TaskBuilder.fs.git</RepositoryUrl>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="TaskBuilder.fs" />
+  </ItemGroup>
+</Project>

--- a/docs/how-to-pack.md
+++ b/docs/how-to-pack.md
@@ -1,0 +1,10 @@
+How to Pack
+===========
+
+To pack the TaskBuilder.fs, use the following command:
+
+```console
+$ dotnet pack -c Release ./TaskBuilder.fs.fsproj
+```
+
+After that, publish the `bin/Release/*.nupkg` files to NuGet.


### PR DESCRIPTION
Hello! I've decided to add the package for .NET Standard 1.6 (because I currently need only 1.6+).

For now, I haven't registered https://www.nuget.org/packages/TaskBuilder.fs/, although I have no problems registering it and maintaining NuGet package if @rspeele is okay with it (I will also share NuGet ownership with anyone @rspeele wants).

Closes #4.

/cc @dustinmoris (you were interested in the packaging)

Currently it's [published on MyGet](https://www.myget.org/feed/fornever/package/nuget/fornever.TaskBuilder.fs) if anybody wants to try it.