### PR TITLE
Added generic overload of TaskBuilderV2.For method

### DIFF
--- a/TaskBuilder.fs
+++ b/TaskBuilder.fs
@@ -272,6 +272,10 @@ module TaskBuilder =
         member __.Combine(step : unit Step, continuation) = combine step continuation
         member __.While(condition : unit -> bool, body : unit -> unit Step) = whileLoop condition body
         member __.For(sequence : _ seq, body : _ -> unit Step) = forLoop sequence body
+        member inline _.For (sequence: ^a, body: 'b -> unit Step) =
+            let mutable e = ( ^a : (member GetEnumerator: unit -> ^Enumerator) sequence)
+            let moveNext () = ( ^Enumerator : (member MoveNext: unit -> bool) e )
+            whileLoop moveNext (fun _ -> body ( ^Enumerator : (member Current: 'b) e))
         member __.TryWith(body : unit -> _ Step, catch : exn -> _ Step) = tryWith body catch
         member __.TryFinally(body : unit -> _ Step, fin : unit -> unit) = tryFinally body fin
         member __.Using(disp : #IDisposable, body : #IDisposable -> _ Step) = using disp body

--- a/TaskBuilder.fs
+++ b/TaskBuilder.fs
@@ -272,7 +272,7 @@ module TaskBuilder =
         member __.Combine(step : unit Step, continuation) = combine step continuation
         member __.While(condition : unit -> bool, body : unit -> unit Step) = whileLoop condition body
         member __.For(sequence : _ seq, body : _ -> unit Step) = forLoop sequence body
-        member inline _.For (sequence: ^a, body: 'b -> unit Step) =
+        member inline __.For (sequence: ^a, body: 'b -> unit Step) =
             let mutable e = ( ^a : (member GetEnumerator: unit -> ^Enumerator) sequence)
             let moveNext () = ( ^Enumerator : (member MoveNext: unit -> bool) e )
             whileLoop moveNext (fun _ -> body ( ^Enumerator : (member Current: 'b) e))


### PR DESCRIPTION
This PR solves problem of iterating over sequences that don't implement `IEnumerable<'T>`, e.g. `System.Buffers.ReadOnlySequence<'T>`.

After applying the changes you should be able to compile code like this:
```fsharp
open System.Text
open System.Buffers
open FSharp.Control.Tasks.V2

let readFromSequence (seq: ReadOnlySequence<byte>) = task {
    for segment in seq do 
        printfn "%s" <| Encoding.UTF8.GetString segment.Span
}
```

Please, @rspeele, give some feedback.