### PR TITLE
Fix exception check on tests

### DIFF
--- a/Test/Program.fs
+++ b/Test/Program.fs
@@ -171,7 +171,11 @@ let testTryFinallySadPath() =
     try
         t.Wait()
     with
-    | _ -> ()
+    | :? AggregateException as e ->
+        match e.InnerExceptions |> Seq.toList with
+        | [TestException "uhoh"] -> ()
+        | _ -> raise e
+    | e -> raise e
     require ran "never ran"
 
 let testTryFinallyCaught() =
@@ -188,7 +192,11 @@ let testTryFinallyCaught() =
                     ran <- true
                 return 1
             with
-            | _ -> return 2
+            | TestException "uhoh" ->
+                return 2
+            | e ->
+                raise e
+                return 3
         }
     require (t.Result = 2) "wrong return"
     require ran "never ran"


### PR DESCRIPTION
These tests were catching all exceptions, even the interesting ones.
Try changing `require (not ran) "ran kinda early"` to `require (ran) "ran kinda early"` and you'll see the test still pass.
This PR fix it by pattern matching on the exception.