### PR TITLE
Remove unused function

### DIFF
--- a/TaskBuilder.fs
+++ b/TaskBuilder.fs
@@ -66,11 +66,6 @@ module TaskBuilder =
                     methodBuilder.AwaitUnsafeOnCompleted(&await, &self)    
             member __.SetStateMachine(_) = () // Doesn't really apply since we're a reference type.
 
-    let unwrapException (agg : AggregateException) =
-        let inners = agg.InnerExceptions
-        if inners.Count = 1 then inners.[0]
-        else agg :> Exception
-
     /// Used to represent no-ops like the implicit empty "else" branch of an "if" expression.
     let zero = Return ()
 


### PR DESCRIPTION
This function was introduced in bd7124e but its usage was immediately removed in a4154bb however the function is still there for nothing.